### PR TITLE
 Bug: Fixed CI broken Live Test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
 
 permissions:
   checks: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 permissions:
   checks: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,10 @@ jobs:
         with:
           distribution: adopt-hotspot
           java-version: ${{ matrix.java-version }}
-      
+
+      - name: DELETE ME - Find java file in GitHub Server, SO ${{matrix.os}}
+        run: find / -type f -name "java" 2>/dev/null
+
       # Run tests & build artifact
       - name: Run tests & build release
         run: ./mvnw package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,14 +31,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Required depth for JReleaser
+
       - name: Setup Java JDK
         uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
           java-version: ${{ matrix.java-version }}
-
-      - name: DELETE ME - Find java file in GitHub Server, SO ${{matrix.os}}
-        run: find / -type f -name "java" 2>/dev/null
 
       # Run tests & build artifact
       - name: Run tests & build release

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <maven.plugins.version>3.3.0</maven.plugins.version>
         <junit.version>5.9.0</junit.version>
     </properties>
 
@@ -95,6 +96,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.plugins.version}</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -109,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <forkCount>1</forkCount>

--- a/src/main/java/software/coley/instrument/io/ByteBufferDataInput.java
+++ b/src/main/java/software/coley/instrument/io/ByteBufferDataInput.java
@@ -2,6 +2,7 @@ package software.coley.instrument.io;
 
 import java.io.DataInput;
 import java.io.UncheckedIOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -107,7 +108,7 @@ public final class ByteBufferDataInput implements DataInput {
 		// Calling slice allows us to limit and set position to 0,
 		// so we can update the actual buffer after decoding is done.
 		ByteBuffer slice = buffer.slice().order(buffer.order());
-		slice.limit(len);
+		((Buffer)slice).limit(len);
 		CharBuffer cb;
 		try {
 			cb = StandardCharsets.UTF_8.newDecoder().decode(slice);

--- a/src/main/java/software/coley/instrument/io/ByteBufferSanitizer.java
+++ b/src/main/java/software/coley/instrument/io/ByteBufferSanitizer.java
@@ -1,5 +1,6 @@
 package software.coley.instrument.io;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 /**
@@ -33,7 +34,7 @@ public final class ByteBufferSanitizer {
 	 * @see ByteBuffer#clear()
 	 */
 	public void clear() {
-		buffer.clear();
+		((Buffer)buffer).clear();
 	}
 
 	/**
@@ -44,7 +45,7 @@ public final class ByteBufferSanitizer {
 	 */
 	public ByteBuffer consume() {
 		ByteBuffer buffer = this.buffer;
-		buffer.flip();
+		((Buffer)buffer).flip();
 		return buffer;
 	}
 
@@ -64,7 +65,7 @@ public final class ByteBufferSanitizer {
 			int pos = buffer.position();
 			size = Integer.highestOneBit(pos + size - 1) << 1;
 			ByteBuffer newBuffer = allocator.allocate(size);
-			buffer.position(0).limit(pos);
+			((Buffer)buffer).position(0).limit(pos);
 			newBuffer.put(buffer);
 			buffer = newBuffer;
 			this.buffer = buffer;

--- a/src/main/java/software/coley/instrument/sock/ChannelHandler.java
+++ b/src/main/java/software/coley/instrument/sock/ChannelHandler.java
@@ -11,6 +11,7 @@ import software.coley.instrument.message.broadcast.AbstractBroadcastMessage;
 import software.coley.instrument.util.Logger;
 import software.coley.instrument.util.NamedThreadFactory;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.ClosedChannelException;
@@ -146,13 +147,13 @@ public class ChannelHandler {
 				// Read next message header
 				while (headerBuffer.position() < HEADER_SIZE)
 					channel.read(headerBuffer);
-				headerBuffer.position(0);
+				((Buffer)headerBuffer).position(0);
 				int readFrameId = headerBuffer.getInt();
 				int messageType = headerBuffer.getShort();
 				int messageLength = headerBuffer.getInt();
 				Logger.debug("Channel read-header: " +
 						"id=" + readFrameId + ", type=" + messageType + ", length=" + messageLength);
-				headerBuffer.clear();
+				((Buffer)headerBuffer).clear();
 				// Read message content
 				contentBuffer = (messageLength > 0) ? ByteBuffer.allocate(messageLength) : EMPTY_BUFFER;
 				while (contentBuffer.position() < messageLength) {
@@ -160,7 +161,7 @@ public class ChannelHandler {
 					if (reads == -1)
 						throw new ClosedChannelException();
 				}
-				contentBuffer.position(0);
+				((Buffer)contentBuffer).position(0);
 				MessageFactory.MessageInfo info = factory.getInfo(messageType);
 				StructureCodec<AbstractMessage> decoder = info.getCodec();
 				AbstractMessage value = decoder.decode(new ByteBufferDataInput(contentBuffer));

--- a/src/test/java/software/coley/instrument/LiveTest.java
+++ b/src/test/java/software/coley/instrument/LiveTest.java
@@ -44,7 +44,6 @@ public class LiveTest {
 	}
 
 	@Test
-	@Timeout(15)
 	@ResourceLock(SERVER) // Use this lock on other tests if they get split later
 	public void test() throws Exception {
 		Process start = null;

--- a/src/test/java/software/coley/instrument/LiveTest.java
+++ b/src/test/java/software/coley/instrument/LiveTest.java
@@ -60,7 +60,8 @@ public class LiveTest {
 		try {
 			// Start the java-agent on the 'Runner' example application
 			String agent = "-javaagent:" + agentJarPath.toString().replace("\\", "/");
-			ProcessBuilder pb = new ProcessBuilder("C:\\Program Files\\AdoptOpenJDK\\jdk-17\\bin\\java", agent, "-cp", "src/test/resources", "Runner");
+//			ProcessBuilder pb = new ProcessBuilder("C:\\Program Files\\AdoptOpenJDK\\jdk-17\\bin\\java", agent, "-cp", "src/test/resources", "Runner");
+			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-17-openjdk/bin/java", agent, "-cp", "src/test/resources", "Runner");
 			pb.inheritIO();
 			start = pb.start();
 

--- a/src/test/java/software/coley/instrument/LiveTest.java
+++ b/src/test/java/software/coley/instrument/LiveTest.java
@@ -3,7 +3,6 @@ package software.coley.instrument;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import software.coley.instrument.data.ClassLoaderInfo;
 import software.coley.instrument.data.MemberData;
@@ -19,7 +18,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/software/coley/instrument/LiveTest.java
+++ b/src/test/java/software/coley/instrument/LiveTest.java
@@ -19,22 +19,24 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Demo setup using the {@code Runner} example class.
  */
-@DisabledIf("checkIsCiServer")
+//@DisabledIf("checkIsCiServer")
 public class LiveTest {
 	private static final String SERVER = "Server";
 	private static Path agentJarPath;
 
-	public static boolean checkIsCiServer() {
-		// I have no idea why attach doesn't work on CI.
-		// It works locally on Java 8-17 just fine.
-		return System.getProperty("user.dir").contains("/home/runner/");
-	}
+//	public static boolean checkIsCiServer() {
+//		// I have no idea why attach doesn't work on CI.
+//		// It works locally on Java 8-17 just fine.
+//		System.out.println("System.getProperty('user.dir'): " + System.getProperty("user.dir"));
+//		return System.getProperty("user.dir").contains("/home/runner/");
+//	}
 
 	@BeforeAll
 	public static void setup() {
@@ -61,9 +63,34 @@ public class LiveTest {
 			// Start the java-agent on the 'Runner' example application
 			String agent = "-javaagent:" + agentJarPath.toString().replace("\\", "/");
 //			ProcessBuilder pb = new ProcessBuilder("C:\\Program Files\\AdoptOpenJDK\\jdk-17\\bin\\java", agent, "-cp", "src/test/resources", "Runner");
-			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-17-openjdk/bin/java", agent, "-cp", "src/test/resources", "Runner");
+			ProcessBuilder pb = new ProcessBuilder("java", agent, "-cp", "src/test/resources", "Runner");
+//			pb.environment().replace("_", "/usr/lib/jvm/java-17-openjdk/bin/java");
+//			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-8-openjdk/jre/bin/java", agent, "-cp", "src/test/resources", "Runner");
+//			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-11-openjdk/bin/java", agent, "-cp", "src/test/resources", "Runner");
+//			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-17-openjdk/bin/java", agent, "-cp", "src/test/resources", "Runner");
+//			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-19-openjdk/bin/java", agent, "-cp", "src/test/resources", "Runner");
+//			ProcessBuilder pb = new ProcessBuilder("/home/wolf/.jdks/corretto-18.0.2/bin/java", agent, "-cp", "src/test/resources", "Runner");
+//			ProcessBuilder pb = new ProcessBuilder("/home/wolf/.jdks/corretto-19.0.2/bin/java", agent, "-cp", "src/test/resources", "Runner");
+//			ProcessBuilder pb = new ProcessBuilder("/home/wolf/.jdks/openjdk-20/bin/java", agent, "-cp", "src/test/resources", "Runner");
+//			ProcessBuilder pb = new ProcessBuilder("/bin/bash", "-c", "java", agent, "-cp", "src/test/resources", "Runner");
+			System.out.println("pb: " + pb);
+			System.out.println("pb.directory(): " + pb.directory());
+			// map view of this process builder's environment
+			Map<String, String> envMap = pb.environment();
+			// checking map view of environment
+			for (Map.Entry<String, String> entry :
+					envMap.entrySet()) {
+				// checking key and value separately
+				System.out.println(entry.getKey()
+						+ ": "
+						+ entry.getValue());
+			}
+			System.out.println("---");
+			System.out.println("_: " + pb.environment().get("_"));
 			pb.inheritIO();
 			start = pb.start();
+			System.out.println("pb: " + pb);
+			System.out.println("pb.directory(): " + pb.directory());
 
 			// Setup our local client
 			Thread.sleep(1500);

--- a/src/test/java/software/coley/instrument/LiveTest.java
+++ b/src/test/java/software/coley/instrument/LiveTest.java
@@ -26,17 +26,9 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Demo setup using the {@code Runner} example class.
  */
-//@DisabledIf("checkIsCiServer")
 public class LiveTest {
 	private static final String SERVER = "Server";
 	private static Path agentJarPath;
-
-//	public static boolean checkIsCiServer() {
-//		// I have no idea why attach doesn't work on CI.
-//		// It works locally on Java 8-17 just fine.
-//		System.out.println("System.getProperty('user.dir'): " + System.getProperty("user.dir"));
-//		return System.getProperty("user.dir").contains("/home/runner/");
-//	}
 
 	@BeforeAll
 	public static void setup() {
@@ -60,37 +52,10 @@ public class LiveTest {
 		Process start = null;
 		Client client = null;
 		try {
-			// Start the java-agent on the 'Runner' example application
 			String agent = "-javaagent:" + agentJarPath.toString().replace("\\", "/");
-//			ProcessBuilder pb = new ProcessBuilder("C:\\Program Files\\AdoptOpenJDK\\jdk-17\\bin\\java", agent, "-cp", "src/test/resources", "Runner");
 			ProcessBuilder pb = new ProcessBuilder("java", agent, "-cp", "src/test/resources", "Runner");
-//			pb.environment().replace("_", "/usr/lib/jvm/java-17-openjdk/bin/java");
-//			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-8-openjdk/jre/bin/java", agent, "-cp", "src/test/resources", "Runner");
-//			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-11-openjdk/bin/java", agent, "-cp", "src/test/resources", "Runner");
-//			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-17-openjdk/bin/java", agent, "-cp", "src/test/resources", "Runner");
-//			ProcessBuilder pb = new ProcessBuilder("/usr/lib/jvm/java-19-openjdk/bin/java", agent, "-cp", "src/test/resources", "Runner");
-//			ProcessBuilder pb = new ProcessBuilder("/home/wolf/.jdks/corretto-18.0.2/bin/java", agent, "-cp", "src/test/resources", "Runner");
-//			ProcessBuilder pb = new ProcessBuilder("/home/wolf/.jdks/corretto-19.0.2/bin/java", agent, "-cp", "src/test/resources", "Runner");
-//			ProcessBuilder pb = new ProcessBuilder("/home/wolf/.jdks/openjdk-20/bin/java", agent, "-cp", "src/test/resources", "Runner");
-//			ProcessBuilder pb = new ProcessBuilder("/bin/bash", "-c", "java", agent, "-cp", "src/test/resources", "Runner");
-			System.out.println("pb: " + pb);
-			System.out.println("pb.directory(): " + pb.directory());
-			// map view of this process builder's environment
-			Map<String, String> envMap = pb.environment();
-			// checking map view of environment
-			for (Map.Entry<String, String> entry :
-					envMap.entrySet()) {
-				// checking key and value separately
-				System.out.println(entry.getKey()
-						+ ": "
-						+ entry.getValue());
-			}
-			System.out.println("---");
-			System.out.println("_: " + pb.environment().get("_"));
 			pb.inheritIO();
 			start = pb.start();
-			System.out.println("pb: " + pb);
-			System.out.println("pb.directory(): " + pb.directory());
 
 			// Setup our local client
 			Thread.sleep(1500);

--- a/src/test/java/software/coley/instrument/LiveTest.java
+++ b/src/test/java/software/coley/instrument/LiveTest.java
@@ -2,7 +2,6 @@ package software.coley.instrument;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import software.coley.instrument.data.ClassLoaderInfo;
 import software.coley.instrument.data.MemberData;


### PR DESCRIPTION
This pull request resolves the [problems related to the broken CI pipeline](https://github.com/Col-E/InstrumentationServer/issues/8).

- [ERROR] java Corrupted STDOUT by directly writing to native stream in forked JVM 1.
  - https://stackoverflow.com/questions/55272870/surefire-maven-plugin-corrupted-stdout-by-directly-writing-to-native-stream-in/61936537#61936537.
- [ERROR] java.lang.NoSuchMethodError: java.nio.ByteBuffer.clear()Ljava/nio/ByteBuffer.
  - https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip#61267496.
- [ERROR] Exception in thread "main" java.lang.reflect.InvocationTargetException.
  - https://stackoverflow.com/questions/59986900/exception-in-thread-main-java-lang-reflect-invocationtargetexception-while-ins/61028211#61028211.
- Restore the Live Test before the “Commit 8be8fd5: Ugh, fine. Disabling live test when on CI server”.

---

**Note:**
- If you want to check the pipeline passing the Live Test, please refer to this pipeline: https://github.com/airvzxf/InstrumentationServer/actions/runs/4579270217/jobs/8086854281.
- The pipeline is broken or red because the release job is breaking in my repository and branch because they are not master.
- Could someone download my changes and tell me if it is working on Windows? https://github.com/airvzxf/InstrumentationServer/tree/bug-ci-broken-live-test.