### PR TITLE
Bind server to 127.0.0.1 instead of localhost

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         run: ./mvnw test
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-${{ matrix.os }}-and-java-${{ matrix.java-version }}
           retention-days: 21
@@ -109,7 +109,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Publish test results
@@ -186,7 +186,7 @@ jobs:
           JRELEASER_NEXUS2_PASSWORD: ${{ secrets.JRELEASER_DEPLOY_MAVEN_NEXUS2_PASSWORD }}
       # Upload JRelease debug log
       - name: JReleaser output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jreleaser-release
           path: |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.coley</groupId>
     <artifactId>instrumentation-server</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
 
     <name>Instrumentation Server</name>
     <description>Minimal client-server library for interacting with remote JVM instrumentation instances</description>

--- a/src/main/java/software/coley/instrument/Agent.java
+++ b/src/main/java/software/coley/instrument/Agent.java
@@ -75,7 +75,7 @@ public class Agent {
 			int port = getPort(agentArgs);
 			// Create server
 			server = Server.open(instrumentation,
-					new InetSocketAddress("localhost", port),
+					new InetSocketAddress("127.0.0.1", port),
 					ByteBufferAllocator.HEAP,
 					MessageFactory.create());
 			Runtime.getRuntime().addShutdownHook(new Thread(() -> server.close()));


### PR DESCRIPTION
Some processes (like Minecraft with the Forge / NeoForge modloader) resolve `localhost` wrongfully for whatever reason, which results in Recaf not being able to attach to those processes (see error below).

Binding to 127.0.0.1 always works.

```
java.io.IOException: Could not connect to remote JVM 15144 over localhost:41725
	at software.coley.recaf.workspace.model.resource.AgentServerRemoteVmResource.connect(AgentServerRemoteVmResource.java:147)
	at software.coley.recaf.ui.pane.RemoteVirtualMachinesPane$VmPane.lambda$new$0(RemoteVirtualMachinesPane.java:233)
	at software.coley.recaf.util.threading.ThreadUtil.lambda$wrap$2(ThreadUtil.java:224)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at software.coley.recaf.util.threading.ThreadUtil.lambda$wrap$2(ThreadUtil.java:224)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: java.net.ConnectException: Connection refused: connect
	at java.base/sun.nio.ch.Net.connect0(Native Method)
	at java.base/sun.nio.ch.Net.connect(Net.java:589)
	at java.base/sun.nio.ch.Net.connect(Net.java:596)
	at java.base/sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:967)
	at software.coley.instrument.Client.connectThrowing(Client.java:111)
	at software.coley.recaf.workspace.model.resource.AgentServerRemoteVmResource.connect(AgentServerRemoteVmResource.java:144)
	... 10 more
```